### PR TITLE
Add link to documentation and deploy docs on master (not main)

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -58,7 +58,7 @@ jobs:
 
   # Single deploy job since we're just deploying
   deploy:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/master'
     needs: build
     environment:
       name: github-pages

--- a/README.md
+++ b/README.md
@@ -41,5 +41,8 @@ conda install -c conda-forge cyipopt
 
 TBW
 
+## Documentation
+See http://aashildte.github.io/mpsadjoint
+
 ## Need help
 Open an [issue](https://github.com/aashildte/mpsadjoint/issues/new) or send me en e-mail me at aashild@simula.no if you have questions.


### PR DESCRIPTION
In order to get the docs to be properly deployed on GitHub pages, you need to go to settings -> pages -> Source -> GitHub actions